### PR TITLE
fix typing error

### DIFF
--- a/app/presenters/HomepagePresenter.php
+++ b/app/presenters/HomepagePresenter.php
@@ -43,7 +43,7 @@ class HomepagePresenter extends BasePresenter {
 		// Všechny tyto konfigurace jsou volitelné:
 
 		// Orientace stránky
-		$pdf->pageOrientaion = PDFResponse::ORIENTATION_LANDSCAPE;
+		$pdf->pageOrientation = PDFResponse::ORIENTATION_LANDSCAPE;
 		// Formát stránky
 		$pdf->pageFormat = "A0";
 		// Okraje stránky


### PR DESCRIPTION
I corrected a typo error in the setter of object PDFResponse.

Nette\MemberAccessException
Cannot write to an undeclared property PdfResponse\PdfResponse::$pageOrientaion.
